### PR TITLE
change 15 port limit to 26 in XHCI kext for 10.13.6 beta 1

### DIFF
--- a/config_patches.plist
+++ b/config_patches.plist
@@ -115,6 +115,16 @@
 				<key>Replace</key>
 				<data>g32UGg+DlwQ=</data>
 			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>change 15 port limit to 26 in XHCI kext for 10.13.6 beta 1 (credit Canvas)</string>
+				<key>Name</key>
+				<string>com.apple.driver.usb.AppleUSBXHCI</string>
+				<key>Find</key>
+				<data>g32IDw+DpwQ=</data>
+				<key>Replace</key>
+				<data>g32IGg+DpwQ=</data>
+			</dict>
 		</array>
 	</dict>
 </dict>


### PR DESCRIPTION
```
<dict>
	<key>Comment</key>
	<string>change 15 port limit to 26 in XHCI kext for 10.13.6 beta 1 (credit Canvas)</string>
	<key>Name</key>
	<string>com.apple.driver.usb.AppleUSBXHCI</string>
        <key>Find</key>
	<data>g32IDw+DpwQ=</data>
	<key>Replace</key>
	<data>g32IGg+DpwQ=</data>
</dict>
```