### PR TITLE
Add USB port limit patch for 10.13.6

### DIFF
--- a/config_patches.plist
+++ b/config_patches.plist
@@ -115,6 +115,18 @@
 				<key>Replace</key>
 				<data>g32UGg+DlwQ=</data>
 			</dict>
+                        <dict>
+                                <key>Comment</key>
+                                <string>change 15 port limit to 26 in XHCI kext (10.13.6) (credit PMHeart)</string>
+                                <key>MatchOS</key>
+                                <string>10.13.6</string>
+                                <key>Name</key>
+                                <string>com.apple.driver.usb.AppleUSBXHCI</string>
+                                <key>Find</key>
+                                <data>g32IDw+DpwQAAA==</data>
+                                <key>Replace</key>
+                                <data>g32ID5CQkJCQkA==</data>
+                        </dict>
 		</array>
 	</dict>
 </dict>


### PR DESCRIPTION
Confirmed working on 10.13.6 final w/ Asus z170 Pro Gaming board