### PR TITLE
List 8086:a36d or 8086:9ded as supported XHCI controllers and remove …

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,10 @@ Typical xHCI needing XHCI-unsupported.kext:
 
 X99-series chipset XHC controller, 8086:8d31
 200-series chipset XHC controller, 8086:a2af (depends on macOS version)
-300-series chipset XHC controller, 8086:a36d or 8086:9ded
 
+Supported xHCI controller (as of 10.14.2, or perhaps earlier):
+
+300-series chipset XHC controller, 8086:a36d or 8086:9ded
 
 ### Build Environment
 

--- a/XHCI-unsupported.kext/Contents/Info.plist
+++ b/XHCI-unsupported.kext/Contents/Info.plist
@@ -73,23 +73,6 @@
 			<key>IOProviderClass</key>
 			<string>IOPCIDevice</string>
 		</dict>
-		<key>AppleUSBXHCISPT 300</key>
-		<dict>
-			<key>CFBundleIdentifier</key>
-			<string>com.apple.driver.usb.AppleUSBXHCIPCI</string>
-			<key>IOClass</key>
-			<string>AppleUSBXHCISPT</string>
-			<key>IOPCIPauseCompatible</key>
-			<true/>
-			<key>IOPCIPrimaryMatch</key>
-			<string>0x9ded8086 0xa36d8086</string>
-			<key>IOPCITunnelCompatible</key>
-			<true/>
-			<key>IOProbeScore</key>
-			<integer>900</integer>
-			<key>IOProviderClass</key>
-			<string>IOPCIDevice</string>
-		</dict>
 	</dict>
 	<key>OSBundleRequired</key>
 	<string>Root</string>


### PR DESCRIPTION
If I understand it correctly, 10.14.2 supports 8086:a36d or 8086:9ded natively.

The file `/System/Library/Extensions/IOUSBHostFamily.kext/Contents/Plugins/AppleUSBXHCIPCI.kext/Contents/Info.plist`

contains:

```
<key>CFBundleIdentifier</key>
<string>com.apple.driver.usb.AppleUSBXHCIPCI</string>
<key>IOClass</key>
<string>AppleIntelCNLUSBXHCI</string>
<key>IOPCIPrimaryMatch</key>
<string>0x9ded8086 0xa36d8086</string>
<key>IOPCITunnelCompatible</key>
<true/>
<key>IOProbeScore</key>
<integer>1000</integer>
<key>IOProviderClass</key>
<string>IOPCIDevice</string>
```

My controller is a `8086:a36d`, and works perfectly without XHCI-unsupported.kext. Let me know if this doesn't make sense or needs to be changed. Thanks!
